### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 services:
 
 ########################


### PR DESCRIPTION
Fixes error "docker-compose build contains unsupported option: 'network'".  
From: https://stackoverflow.com/questions/62484158/docker-compose-build-contains-unsupported-option-network